### PR TITLE
Fix an upload bug

### DIFF
--- a/octoprint_slic3r/static/js/slic3r.js
+++ b/octoprint_slic3r/static/js/slic3r.js
@@ -59,6 +59,7 @@ $(function() {
             dataType: "json",
             maxNumberOfFiles: 1,
             autoUpload: false,
+            headers: OctoPrint.getRequestHeaders(),
             add: function(e, data) {
                 if (data.files.length == 0) {
                     return false;
@@ -71,6 +72,7 @@ $(function() {
                 self.placeholderDisplayName(name);
                 self.placeholderDescription("Imported from " + self.fileName() + " on " + formatDate(new Date().getTime() / 1000));
 
+                self.uploadButton.unbind("click");
                 self.uploadButton.on("click", function() {
                     var form = {
                         allowOverwrite: self.profileAllowOverwrite()


### PR DESCRIPTION
Fixes a bug where a file gets uploaded over and over again.
Because of constantly binding new click events to the upload button, without unbinding the old ones.